### PR TITLE
Pat/build fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Jenkins-Swift
 ---
-
+![Latest](http://img.shields.io/badge/Latest-0.0.3-brightgreen.svg)
 ![Swift](http://img.shields.io/badge/swift-3.0-brightgreen.svg)
 [![Build Status](https://travis-ci.org/IntrepidPursuits/Jenkins-swift.svg?branch=master)](https://travis-ci.org/IntrepidPursuits/Jenkins-swift)
 
@@ -23,7 +23,7 @@ For example if your jobs live at `http://jenkins.myHost.com:8080/jobs/`
 
 You can initialize the jenkins client like so:
 
-    jenkins = try! Jenkins(host: "jenkins.myHost.com",
+    jenkins = try Jenkins(host: "jenkins.myHost.com",
                            port: 8080,
                            user: "MyUsername",
                           token: "MyAPIToken",

--- a/Sources/APIClient.swift
+++ b/Sources/APIClient.swift
@@ -99,6 +99,7 @@ internal final class APIClient: NSObject {
         _ = headers.map { request.addValue($0.value, forHTTPHeaderField: $0.key) }
         
         if let body = body {
+            request.addValue("application/x-www-form-urlencoded; charset=utf-8", forHTTPHeaderField: "Content-Type")
             request.httpBody = body
         } else {
             var components = URLComponents(url: url, resolvingAgainstBaseURL: false)


### PR DESCRIPTION
Fixes an issue where `buildWithParameters` would throw a 500 error without the proper `Content-Type` header set.

Updates the README to show the latest build version. 
